### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ click and the web app will be open in your Web browser.
 
 <br>
 # Creating a Flask Website for NLP <br>
-
+[![Run on Repl.it](https://repl.it/badge/github/pemagrg1/NLP-Flask-Website)](https://repl.it/github/pemagrg1/NLP-Flask-Website)
 ![nlpgif](NLPFlask.gif)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@PriyaSanjay/NLP-Flask-Website).